### PR TITLE
refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,25 @@ This library wrapps around terraform and eases the workflow by handling
 - automatic backend initialization
 - plan file handling
 
+### Install
+
+Add the following to your `Makefile`
+```
+STATE_NAME = my-awesome-workspace
+
+-include $(shell curl -sSL -o .terraform-make.mk "https://git.io/terraform-make"; echo .terraform-make.mk)
+```
+
+Install the library
+```bash
+make install
+```
+
+The following environment variables can be used to adjust repo and install path
+```bash
+export TF_MAKE_BRANCH=master
+export TF_MAKE_CLONE_URL=https://github.com/janschumann/terraform-make.git
+export TF_MAKE_PATH=.terraform-make
+```
+
+

--- a/aws-session.sh
+++ b/aws-session.sh
@@ -144,7 +144,7 @@ fi
 
 CMD="aws sts --profile ${PROFILE} assume-role \
     --role-arn arn:aws:iam::${TO_ACCOUNT_ID}:role/${ROLE} \
-    --role-session-name ${TO_ACCOUNT_ID}-${TO_PROFILE}-${ROLE} \
+    --role-session-name ${TO_PROFILE}-${USER}  \
     --serial-number arn:aws:iam::${MAIN_ACCOUNT_ID}:mfa/${USER} \
     --token-code ${TOKEN}"
 

--- a/aws.mk
+++ b/aws.mk
@@ -62,9 +62,6 @@ else
 	REGION ?= $(VAR_FILE_REGION)
 endif
 
-ifeq ($(VERBOSE),true)
-	AWS_SESSION_VERBOSE_ARG = "-v"
-endif
 AWS_ROLE_NAME ?= $(AWS_DEFAULT_ROLE_NAME)
 
 ifeq ($(IS_DEPLOYMENT),true)
@@ -118,9 +115,6 @@ verify-credentials: warn-env-credentials
 	@if [ -z "$(ACCESS_KEY_ID)" ]; then echo "$(RED)Please define an access key$(NC)"; exit 1; fi
 	@if [ -z "$(SECRET_ACCESS_KEY)" ]; then echo "$(RED)Please define an secret access key$(NC)"; exit 1; fi
 
-verify-active-session: warn-env-credentials
-	@if [ "1" = "$(IS_EXPIRED)" ]; then echo "$(RED)Your Session $(YELLOW)$(AWS_PROFILE)$(RED) has expired. Aborting.$(NC)"; exit 1; fi
-
 warn-env-credentials:
 	@if [ "$(shell env | grep AWS_PROFILE)" ]; then echo "$(YELLOW)WARNING: AWS_PROFILE is defined as env variable$(NC)"; fi
 	@if [ "$(shell env | grep AWS_ACCESS_KEY_ID)" ]; then echo "$(YELLOW)WARNING: AWS_ACCESS_KEY_ID is defined as env variable$(NC)"; fi
@@ -132,7 +126,7 @@ force-session: reset-account-config
 	$(MAKE) session
 
 access-$(AWS_ROLE_NAME): verify-aws warn-env-credentials
-	@if [ "1" = "$(IS_EXPIRED)" ]; then $(TERRAFORM_MAKE_LIB_HOME)/aws-session.sh -o $(ORGANISATION) -p $(SESSION_TARGET_PROFILE) -r $(AWS_ROLE_NAME) $(AWS_SESSION_VERBOSE_ARG); fi
+	@if [ "1" = "$(IS_EXPIRED)" ]; then $(TERRAFORM_MAKE_LIB_HOME)/aws-session.sh -o $(ORGANISATION) -p $(SESSION_TARGET_PROFILE) -r $(AWS_ROLE_NAME); fi
 
 show-session-profile:
 	@echo $(ORGANISATION)-$(ACCOUNT)-$(ENVIRONMENT)

--- a/azure.mk
+++ b/azure.mk
@@ -38,9 +38,6 @@ verify-azure:
 	@if [ -z "$(ENVIRONMENT)" ]; then echo "$(RED)Please define an ENVIRONMENT$(NC)"; exit 1; fi
 	@command -v $(AZURE_CLI) > /dev/null || echo "$(RED)azure cli not installed$(NC)"
 
-verify-active-session: verify-azure
-	@$(AZURE_CLI) account list | jq '.[].name' | grep $(ENVIRONMENT) &> /dev/null || (echo "$(RED)Subscription not found. Need az login?$(NC) $(YELLOW)$(ENVIRONMENT)$(NC)"; exit 1)
-
 session: azure-login
 	@ true
 

--- a/install.mk
+++ b/install.mk
@@ -1,0 +1,13 @@
+TF_MAKE_BRANCH ?= master
+TF_MAKE_CLONE_URL ?= https://github.com/janschumann/terraform-make.git
+TF_MAKE_PATH ?= terraform-make
+
+-include $(TF_MAKE_PATH)/terraform.mk
+
+.PHONY : install
+install::
+	@ git clone -c advice.detachedHead=false --depth=1 -b $(TF_MAKE_BRANCH) $(TF_MAKE_CLONE_URL) $(TF_MAKE_PATH)
+
+.PHONY : clean
+clean::
+	@ rm -rf $(TF_MAKE_PATH)

--- a/install.mk
+++ b/install.mk
@@ -2,12 +2,14 @@ TF_MAKE_BRANCH ?= master
 TF_MAKE_CLONE_URL ?= https://github.com/janschumann/terraform-make.git
 TF_MAKE_PATH ?= .terraform-make
 
--include $(TF_MAKE_PATH)/terraform.mk
+TERRAFORM_MAKE_LIB_HOME := $(shell pwd)/$(TF_MAKE_PATH)
+
+-include $(TERRAFORM_MAKE_LIB_HOME)/terraform.mk
 
 .PHONY : install
 install::
-	@ git clone -c advice.detachedHead=false --depth=1 -b $(TF_MAKE_BRANCH) $(TF_MAKE_CLONE_URL) $(TF_MAKE_PATH)
+	@git clone -c advice.detachedHead=false --depth=1 -b $(TF_MAKE_BRANCH) $(TF_MAKE_CLONE_URL) $(TERRAFORM_MAKE_LIB_HOME)
 
 .PHONY : clean
 clean::
-	@ rm -rf $(TF_MAKE_PATH)
+	@ rm -rf $(TERRAFORM_MAKE_LIB_HOME)

--- a/install.mk
+++ b/install.mk
@@ -1,6 +1,6 @@
 TF_MAKE_BRANCH ?= master
 TF_MAKE_CLONE_URL ?= https://github.com/janschumann/terraform-make.git
-TF_MAKE_PATH ?= terraform-make
+TF_MAKE_PATH ?= .terraform-make
 
 -include $(TF_MAKE_PATH)/terraform.mk
 

--- a/terraform-backend-azurerm.mk
+++ b/terraform-backend-azurerm.mk
@@ -3,22 +3,14 @@ STATE_KEY ?= $(STATE_NAME).tfstate
 AZURERM_BACKEND_SUBSCRIPTION ?= $(ENVIRONMENT)
 BACKEND_TERRAFORM_INIT_ARGS = -backend-config="storage_account_name=$(AZURERM_BACKEND_STORAGE_ACCOUNT_NAME)" -backend-config="container_name=$(STATE_BACKEND_CONTAINER)" -backend-config="access_key=$(AZURERM_BACKEND_STORAGE_ACCOUNT_ACCESS_KEY)" -backend-config="key=$(STATE_KEY)"
 
-ifeq ($(SKIP_BACKEND),true)
-	BACKEND_TERRAFORM_INIT_ARGS = -backend=false
-endif
-
-ifneq ($(SKIP_BACKEND),true)
-	LOCAL_STATE_FILE := $(TERRAFORM_CACHE_DIR)/terraform.tfstate
-endif
-
+init: LOCAL_STATE_FILE := $(TERRAFORM_CACHE_DIR)/terraform.tfstate
 init: CURRENT_STATE_KEY = $(shell if [ -f $(LOCAL_STATE_FILE) ]; then cat $(LOCAL_STATE_FILE) | grep "\"key\":" | awk -F\" '{print $$4}'; fi)
 init: CURRENT_PROFILE = $(shell if [ -f $(LOCAL_STATE_FILE) ]; then cat $(LOCAL_STATE_FILE) | grep "\"profile\":" | awk -F\" '{print $$4}'; fi)
-init:
+init: session
 	$(shell if [ "$(SKIP_BACKEND)" == "false" ] && ([ "$(IS_DEPLOYMENT)" == "true" ] || [ "$(CURRENT_PROFILE)" != "$(AWS_PROFILE)" ] || [ "$(CURRENT_STATE_KEY)" != "$(STATE_KEY)" ]); then echo $(MAKE) force-init; fi)
 
-ensure-backend:
+backend.tf:
 	@echo "terraform { \n  backend \"azurerm\" {} \n}" > backend.tf
-	$(shell if [ "$(SKIP_BACKEND)" == "true" ]; then rm -rf backend.tf; fi)
 
 AZURERM_BACKEND_STATE_ENV_SUFFIX = env:$(ENVIRONMENT)
 ifeq ($(ENVIRONMENT),default)

--- a/terraform-backend-local.mk
+++ b/terraform-backend-local.mk
@@ -2,8 +2,14 @@
 ### Local state
 ###
 
-BACKEND_TERRAFORM_INIT_ARGS := -backend=false
-LOCAL_STATE_FILE := terraform.tfstate.d/$(ENVIRONMENT)/terraform.tfstate
+TERRAFORM_STATE_LOCK := false
+BACKEND_TERRAFORM_INIT_ARGS :=
 
-init:
-	$(shell if [ ! -f $(LOCAL_STATE_FILE) ]; then echo $(MAKE) force-init; fi)
+init: LOCAL_STATE_DIR := terraform.tfstate.d/$(ENVIRONMENT)
+init: session
+	$(shell if [ ! -d $(LOCAL_STATE_DIR) ]; then echo $(MAKE) force-init ensure-workspace; fi)
+	@echo "$(ACCOUNT)" > $(TERRAFORM_CACHE_DIR)/local_backend_account.txt
+
+clean-state:
+	@rm -f $(TERRAFORM_CACHE_DIR)/local_backend_account.txt
+	@rm -f $(TERRAFORM_CACHE_DIR)/environment

--- a/terraform-backend-local.mk
+++ b/terraform-backend-local.mk
@@ -7,9 +7,9 @@ BACKEND_TERRAFORM_INIT_ARGS :=
 
 init: LOCAL_STATE_DIR := terraform.tfstate.d/$(ENVIRONMENT)
 init: session
-	$(shell if [ ! -d $(LOCAL_STATE_DIR) ]; then echo $(MAKE) force-init ensure-workspace; fi)
-	@echo "$(ACCOUNT)" > $(TERRAFORM_CACHE_DIR)/local_backend_account.txt
+	$(shell if [ ! -d $(LOCAL_STATE_DIR) ]; then echo $(MAKE) force-init; fi)
+	@echo "$(ACCOUNT)" > $(TERRAFORM_CACHE_DIR)/backend-local-account
 
 clean-state:
-	@rm -f $(TERRAFORM_CACHE_DIR)/local_backend_account.txt
+	@rm -f $(TERRAFORM_CACHE_DIR)/backend-local-account
 	@rm -f $(TERRAFORM_CACHE_DIR)/environment

--- a/terraform-backend-s3.mk
+++ b/terraform-backend-s3.mk
@@ -4,6 +4,9 @@
 ### Requires aws-session.mk to be included before
 ###
 
+# s3 supports locking
+TERRAFORM_STATE_LOCK := true
+
 # the region where the state backend is located
 STATE_BACKEND_REGION ?= $(DEFAULT_REGION)
 
@@ -12,13 +15,9 @@ STATE_BACKEND_REGION ?= $(DEFAULT_REGION)
 # => storate container in azure
 STATE_CONTAINER ?= $(ORGANISATION)-terraform-state
 
-STATE_LOCK_TABLE = terraform-state-lock
-
-# the state name is part of the state key
-STATE_NAME ?= account
-
-# the state key
-STATE_KEY ?= $(ACCOUNT)/$(REGION)/$(STATE_NAME).tfstate
+STATE_LOCK_TABLE ?= terraform-state-lock
+STATE_ENCRYPT ?= true
+STATE_ACL ?= authenticated-read
 
 # the kms key to encrypt state files in s3
 VAR_FILE_KMS_KEY_ARN := $(shell if [ -f $(VAR_FILE) ]; then cat $(VAR_FILE) | grep "^kms_key_id[[:space:]]*=" | sed 's/^[^"]*"\(.*\)".*/\1/'; fi)
@@ -28,60 +27,36 @@ else
 	KMS_KEY_ARN ?= $(VAR_FILE_KMS_KEY_ARN)
 endif
 
-STATE_ENCRYPT ?= true
-# no encryption if no backend should be used
-ifeq ($(SKIP_BACKEND),true)
-	STATE_ENCRYPT = false
-endif
+# the state name is part of the state key
+STATE_NAME ?= unknown
 
-ifeq ($(STATE_ENCRYPT),false)
-	KMS_KEY_ARN :=
-endif
+# the state key
+STATE_KEY ?= $(ACCOUNT)/$(REGION)/$(STATE_NAME).tfstate
 
-STATE_BACKEND_S3_CONFIG_INIT_ARGS = -backend-config="bucket=$(STATE_CONTAINER)" -backend-config="key=$(STATE_KEY)" -backend-config="region=$(STATE_BACKEND_REGION)" -backend-config="encrypt=$(STATE_ENCRYPT)" -backend-config="acl=authenticated-read"
-MIN_STATE_BACKEND_S3_CONFIG_INIT_ARGS = $(STATE_BACKEND_S3_CONFIG_INIT_ARGS)
-ifeq ($(TERRAFORM_STATE_LOCK),true)
-	MIN_STATE_BACKEND_S3_CONFIG_INIT_ARGS = $(STATE_BACKEND_S3_CONFIG_INIT_ARGS) -backend-config="dynamodb_table=$(STATE_LOCK_TABLE)"
-endif
-MIN_STATE_BACKEND_S3_INIT_ARGS = $(MIN_STATE_BACKEND_S3_CONFIG_INIT_ARGS)
+BACKEND_TERRAFORM_INIT_ARGS = -backend-config="key=$(STATE_KEY)"
 # only add profile backend config, if not deploying
 # on deployment, the IAM instance profile of the jenkins build slave
 # should be used
 ifneq ($(IS_DEPLOYMENT),true)
-	MIN_STATE_BACKEND_S3_INIT_ARGS = $(MIN_STATE_BACKEND_S3_CONFIG_INIT_ARGS) -backend-config="profile=$(AWS_PROFILE)"
+	BACKEND_TERRAFORM_INIT_ARGS := $(BACKEND_TERRAFORM_INIT_ARGS) -backend-config="profile=$(AWS_PROFILE)"
 endif
 
-BACKEND_TERRAFORM_INIT_ARGS = $(MIN_STATE_BACKEND_S3_INIT_ARGS)
-ifneq ($(KMS_KEY_ARN),)
-	BACKEND_TERRAFORM_INIT_ARGS = $(MIN_STATE_BACKEND_S3_INIT_ARGS) -backend-config="kms_key_id=$(KMS_KEY_ARN)"
-endif
-
-ifeq ($(SKIP_BACKEND),true)
-	BACKEND_TERRAFORM_INIT_ARGS = -backend=false
-endif
-
-ifneq ($(SKIP_BACKEND),true)
-	LOCAL_STATE_FILE := $(TERRAFORM_CACHE_DIR)/terraform.tfstate
-endif
-
-init: CURRENT_STATE_KEY = $(shell if [ -f $(LOCAL_STATE_FILE) ]; then cat $(LOCAL_STATE_FILE) | grep "\"key\":" | awk -F\" '{print $$4}'; fi)
-init: CURRENT_PROFILE = $(shell if [ -f $(LOCAL_STATE_FILE) ]; then cat $(LOCAL_STATE_FILE) | grep "\"profile\":" | awk -F\" '{print $$4}'; fi)
-init: warn-env-credentials
+init: LOCAL_STATE_FILE := $(TERRAFORM_CACHE_DIR)/terraform.tfstate
+init: CURRENT_STATE_KEY := $(shell if [ -f $(LOCAL_STATE_FILE) ]; then cat $(LOCAL_STATE_FILE) | grep "\"key\":" | awk -F\" '{print $$4}'; fi)
+init: CURRENT_PROFILE := $(shell if [ -f $(LOCAL_STATE_FILE) ]; then cat $(LOCAL_STATE_FILE) | grep "\"profile\":" | awk -F\" '{print $$4}'; fi)
+init: session backend.tf warn-env-credentials
 	$(shell if [ ! -f $(LOCAL_STATE_FILE) ] || ([ "$(IS_DEPLOYMENT)" != "true" ] && ([ "$(CURRENT_PROFILE)" != "$(AWS_PROFILE)" ] || [ "$(CURRENT_STATE_KEY)" != "$(STATE_KEY)" ])); then echo $(MAKE) force-init; fi)
 
-disable-backend:
-	@$(shell mv backend.tf backend.tf.disabled || true)
+backend.tf:
+	@sed 's|$${state_bucket}|$(ORGANISATION)-terraform-state|' $(TERRAFORM_MAKE_LIB_HOME)/terraform-backend-s3.tf.tpl | sed 's|$${state_kms_key_id}|$(KMS_KEY_ARN)|' | sed 's|$${state_region}|$(STATE_BACKEND_REGION)|' | sed 's|$${state_lock_table}|$(STATE_LOCK_TABLE)|' | sed 's|$${state_encrypt}|$(STATE_ENCRYPT)|' | sed 's|$${state_acl}|$(STATE_ACL)|' > backend.tf
 
-enable-backend:
-	@$(shell mv backend.tf.disabled backend.tf || true)
-	@if [[ ! -f backend.tf ]]; then echo "$(RED)Could not enable backend!!$(NC)"; exit 1; fi
-
-backup-local-state: ensure-environment
-	@mv terraform.tfstate.d/$(ENVIRONMENT)/terraform.tfstate $(ACCOUNT)-$(ENVIRONMENT).tfstate
-
-push-local-state: ensure-environment enable-backend force-init ensure-workspace
+push-local-state: ensure-environment force-init ensure-workspace
 	@echo
 	@echo "$(YELLOW)You are uploading a local state to s3$(NC)!!"
 	@read -p "Are you sure? (only yes will be accepted): " deploy; \
 	if [[ $$deploy != "yes" ]]; then exit 1; fi
 	$(TERRAFORM) state push $(ACCOUNT)-$(ENVIRONMENT).tfstate
+
+clean-state:
+	@rm -f $(TERRAFORM_CACHE_DIR)/terraform.tfstate
+	@rm -f $(TERRAFORM_CACHE_DIR)/environment

--- a/terraform-backend-s3.mk
+++ b/terraform-backend-s3.mk
@@ -1,7 +1,7 @@
 ###
 ### S3 backend extension for terraform.mk
 ###
-### Requires aws-session.mk to be included before
+### Requires aws.mk to be included before
 ###
 
 # s3 supports locking
@@ -44,10 +44,10 @@ endif
 init: LOCAL_STATE_FILE := $(TERRAFORM_CACHE_DIR)/terraform.tfstate
 init: CURRENT_STATE_KEY := $(shell if [ -f $(LOCAL_STATE_FILE) ]; then cat $(LOCAL_STATE_FILE) | grep "\"key\":" | awk -F\" '{print $$4}'; fi)
 init: CURRENT_PROFILE := $(shell if [ -f $(LOCAL_STATE_FILE) ]; then cat $(LOCAL_STATE_FILE) | grep "\"profile\":" | awk -F\" '{print $$4}'; fi)
-init: session backend.tf warn-env-credentials
+init: backend.tf warn-env-credentials
 	$(shell if [ ! -f $(LOCAL_STATE_FILE) ] || ([ "$(IS_DEPLOYMENT)" != "true" ] && ([ "$(CURRENT_PROFILE)" != "$(AWS_PROFILE)" ] || [ "$(CURRENT_STATE_KEY)" != "$(STATE_KEY)" ])); then echo $(MAKE) force-init; fi)
 
-backend.tf:
+backend.tf: verify-aws
 	@sed 's|$${state_bucket}|$(ORGANISATION)-terraform-state|' $(TERRAFORM_MAKE_LIB_HOME)/terraform-backend-s3.tf.tpl | sed 's|$${state_kms_key_id}|$(KMS_KEY_ARN)|' | sed 's|$${state_region}|$(STATE_BACKEND_REGION)|' | sed 's|$${state_lock_table}|$(STATE_LOCK_TABLE)|' | sed 's|$${state_encrypt}|$(STATE_ENCRYPT)|' | sed 's|$${state_acl}|$(STATE_ACL)|' > backend.tf
 
 push-local-state: ensure-environment force-init ensure-workspace

--- a/terraform-backend-s3.tf.tpl
+++ b/terraform-backend-s3.tf.tpl
@@ -1,0 +1,12 @@
+terraform {
+  backend "s3" {
+    bucket         = "${state_bucket}"
+    kms_key_id     = "${state_kms_key_id}"
+    region         = "${state_region}"
+    encrypt        = ${state_encrypt}
+    acl            = "${state_acl}"
+    dynamodb_table = "${state_lock_table}"
+    key            = "" # set by cli param
+    profile        = "" # set by cli param
+  }
+}

--- a/terraform-local-state-backend-local.mk
+++ b/terraform-local-state-backend-local.mk
@@ -1,0 +1,8 @@
+# try to load account and environment
+# from local state and determine the VAR_FILE name
+ifneq ($(wildcard $(TERRAFORM_CACHE_DIR)/local_backend_account.txt),)
+	LOCAL_STATE_ACCOUNT = $(shell cat $(TERRAFORM_CACHE_DIR)/local_backend_account.txt)
+ifneq ($(wildcard $(TERRAFORM_CACHE_DIR)/environment),)
+	VAR_FILE := $(LOCAL_STATE_ACCOUNT)-$(shell cat $(TERRAFORM_CACHE_DIR)/environment).tfvars
+endif
+endif

--- a/terraform-local-state-backend-local.mk
+++ b/terraform-local-state-backend-local.mk
@@ -1,7 +1,12 @@
-# try to load account and environment
-# from local state and determine the VAR_FILE name
-ifneq ($(wildcard $(TERRAFORM_CACHE_DIR)/local_backend_account.txt),)
-	LOCAL_STATE_ACCOUNT = $(shell cat $(TERRAFORM_CACHE_DIR)/local_backend_account.txt)
+#
+# Extends terraform-backend-local.mk
+#
+# Fetch ACCOUNT and ENVIRONMENT from local state files
+# and build the VAR_FILE
+#
+
+ifneq ($(wildcard $(TERRAFORM_CACHE_DIR)/backend-local-account),)
+	LOCAL_STATE_ACCOUNT = $(shell cat $(TERRAFORM_CACHE_DIR)/backend-local-account)
 ifneq ($(wildcard $(TERRAFORM_CACHE_DIR)/environment),)
 	VAR_FILE := $(LOCAL_STATE_ACCOUNT)-$(shell cat $(TERRAFORM_CACHE_DIR)/environment).tfvars
 endif

--- a/terraform-local-state-backend-s3.mk
+++ b/terraform-local-state-backend-s3.mk
@@ -1,0 +1,6 @@
+# try to load account and environment
+# from local state and determine the VAR_FILE name
+INIT_STATE_FILE := $(TERRAFORM_CACHE_DIR)/terraform.tfstate
+ifneq ($(wildcard $(INIT_STATE_FILE)),)
+	VAR_FILE := $(shell cat $(INIT_STATE_FILE) | grep "\"key\":" | awk -F\" '{print $$4}' | awk -F/ '{print $$1}')-$(shell cat $(INIT_STATE_FILE) | grep "\"profile\":" | awk -F\" '{print $$4}' | awk -F- '{print $$3}').tfvars
+endif

--- a/terraform-local-state-backend-s3.mk
+++ b/terraform-local-state-backend-s3.mk
@@ -1,6 +1,11 @@
-# try to load account and environment
-# from local state and determine the VAR_FILE name
+#
+# Extends terraform-backend-s3.mk
+#
+# Fetch ACCOUNT and ENVIRONMENT from local state files
+# and build the VAR_FILE
+#
+
 INIT_STATE_FILE := $(TERRAFORM_CACHE_DIR)/terraform.tfstate
 ifneq ($(wildcard $(INIT_STATE_FILE)),)
-	VAR_FILE := $(shell cat $(INIT_STATE_FILE) | grep "\"key\":" | awk -F\" '{print $$4}' | awk -F/ '{print $$1}')-$(shell cat $(INIT_STATE_FILE) | grep "\"profile\":" | awk -F\" '{print $$4}' | awk -F- '{print $$3}').tfvars
+	VAR_FILE := $(shell cat $(INIT_STATE_FILE) | grep "\"profile\":" | awk -F\" '{print $$4}' | awk -F- '{print $$2}')-$(shell cat $(INIT_STATE_FILE) | grep "\"profile\":" | awk -F\" '{print $$4}' | awk -F- '{print $$3}').tfvars
 endif

--- a/terraform.mk
+++ b/terraform.mk
@@ -144,10 +144,8 @@ debug-default:
 	@echo CURRENT_PLAN_FILE=$(CURRENT_PLAN_FILE)
 	@echo PLAN=$(PLAN)
 	@echo PLAN_OUT=$(PLAN_OUT)
-	@echo LOCAL_STATE_FILE=$(LOCAL_STATE_FILE)
 	@echo STATE_KEY=$(STATE_KEY)
 	@echo IS_DEPLOYMENT=$(IS_DEPLOYMENT)
-	@echo SKIP_BACKEND=$(SKIP_BACKEND)
 	@echo BACKEND_TYPE=$(BACKEND_TYPE)
 	@echo TERRAFORM_CMD=$(TERRAFORM_CMD)
 	@echo TERRAFORM=$(TERRAFORM)
@@ -263,9 +261,10 @@ default: fmt validate
 TF_ARGS_INIT = $(BACKEND_TERRAFORM_INIT_ARGS)
 
 # force re-initialization of terraform state
-force-init: backend.tf install-community-plugins before-init clean-state .tf-init ensure-workspace
+force-init: backend.tf install-community-plugins before-init clean-state .tf-init
+	@$(MAKE) ensure-workspace
 
-.tf-init:
+.tf-init: session
 	$(TERRAFORM) init $(TF_ARGS_INIT)
 
 # update modules


### PR DESCRIPTION
* add defaults for provider and backend type
  * TERRAFORM_PROVIDER=aws
  * BACKEND_TYPE=s3
* MFA token for AWS session can now be fetched by exporting AWS_MFA_TOKEN_CMD env variable 
```
# 1password cli
export AWS_MFA_TOKEN_CMD="op get  totp <id>"
make VAR_FILE=<account>-<env>.tfvars session
```
* Backend config `backend.tf` is now fully maintained. => `backend.tf` can be added to gitignore
* Once an environment has been initialised, the VAR_FILE parameter can now be omitted on subsequent commands
```
make VAR_FILE=<account>-<env>.tfvars force-init
make force-plan
``` 
* add installer
