### PR TITLE
refactoring (#1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,25 @@ This library wrapps around terraform and eases the workflow by handling
 - automatic backend initialization
 - plan file handling
 
+### Install
+
+Add the following to your `Makefile`
+```
+STATE_NAME = my-awesome-workspace
+
+-include $(shell curl -sSL -o .terraform-make.mk "https://git.io/terraform-make"; echo .terraform-make.mk)
+```
+
+Install the library
+```bash
+make install
+```
+
+The following environment variables can be used to adjust repo and install path
+```bash
+export TF_MAKE_BRANCH=master
+export TF_MAKE_CLONE_URL=https://github.com/janschumann/terraform-make.git
+export TF_MAKE_PATH=.terraform-make
+```
+
+

--- a/aws-session.sh
+++ b/aws-session.sh
@@ -144,7 +144,7 @@ fi
 
 CMD="aws sts --profile ${PROFILE} assume-role \
     --role-arn arn:aws:iam::${TO_ACCOUNT_ID}:role/${ROLE} \
-    --role-session-name ${TO_ACCOUNT_ID}-${TO_PROFILE}-${ROLE} \
+    --role-session-name ${TO_PROFILE}-${USER}  \
     --serial-number arn:aws:iam::${MAIN_ACCOUNT_ID}:mfa/${USER} \
     --token-code ${TOKEN}"
 

--- a/aws.mk
+++ b/aws.mk
@@ -62,9 +62,6 @@ else
 	REGION ?= $(VAR_FILE_REGION)
 endif
 
-ifeq ($(VERBOSE),true)
-	AWS_SESSION_VERBOSE_ARG = "-v"
-endif
 AWS_ROLE_NAME ?= $(AWS_DEFAULT_ROLE_NAME)
 
 ifeq ($(IS_DEPLOYMENT),true)
@@ -118,9 +115,6 @@ verify-credentials: warn-env-credentials
 	@if [ -z "$(ACCESS_KEY_ID)" ]; then echo "$(RED)Please define an access key$(NC)"; exit 1; fi
 	@if [ -z "$(SECRET_ACCESS_KEY)" ]; then echo "$(RED)Please define an secret access key$(NC)"; exit 1; fi
 
-verify-active-session: warn-env-credentials
-	@if [ "1" = "$(IS_EXPIRED)" ]; then echo "$(RED)Your Session $(YELLOW)$(AWS_PROFILE)$(RED) has expired. Aborting.$(NC)"; exit 1; fi
-
 warn-env-credentials:
 	@if [ "$(shell env | grep AWS_PROFILE)" ]; then echo "$(YELLOW)WARNING: AWS_PROFILE is defined as env variable$(NC)"; fi
 	@if [ "$(shell env | grep AWS_ACCESS_KEY_ID)" ]; then echo "$(YELLOW)WARNING: AWS_ACCESS_KEY_ID is defined as env variable$(NC)"; fi
@@ -132,7 +126,7 @@ force-session: reset-account-config
 	$(MAKE) session
 
 access-$(AWS_ROLE_NAME): verify-aws warn-env-credentials
-	@if [ "1" = "$(IS_EXPIRED)" ]; then $(TERRAFORM_MAKE_LIB_HOME)/aws-session.sh -o $(ORGANISATION) -p $(SESSION_TARGET_PROFILE) -r $(AWS_ROLE_NAME) $(AWS_SESSION_VERBOSE_ARG); fi
+	@if [ "1" = "$(IS_EXPIRED)" ]; then $(TERRAFORM_MAKE_LIB_HOME)/aws-session.sh -o $(ORGANISATION) -p $(SESSION_TARGET_PROFILE) -r $(AWS_ROLE_NAME); fi
 
 show-session-profile:
 	@echo $(ORGANISATION)-$(ACCOUNT)-$(ENVIRONMENT)

--- a/azure.mk
+++ b/azure.mk
@@ -38,9 +38,6 @@ verify-azure:
 	@if [ -z "$(ENVIRONMENT)" ]; then echo "$(RED)Please define an ENVIRONMENT$(NC)"; exit 1; fi
 	@command -v $(AZURE_CLI) > /dev/null || echo "$(RED)azure cli not installed$(NC)"
 
-verify-active-session: verify-azure
-	@$(AZURE_CLI) account list | jq '.[].name' | grep $(ENVIRONMENT) &> /dev/null || (echo "$(RED)Subscription not found. Need az login?$(NC) $(YELLOW)$(ENVIRONMENT)$(NC)"; exit 1)
-
 session: azure-login
 	@ true
 

--- a/install.mk
+++ b/install.mk
@@ -1,0 +1,15 @@
+TF_MAKE_BRANCH ?= master
+TF_MAKE_CLONE_URL ?= https://github.com/janschumann/terraform-make.git
+TF_MAKE_PATH ?= .terraform-make
+
+TERRAFORM_MAKE_LIB_HOME := $(shell pwd)/$(TF_MAKE_PATH)
+
+-include $(TERRAFORM_MAKE_LIB_HOME)/terraform.mk
+
+.PHONY : install
+install::
+	@git clone -c advice.detachedHead=false --depth=1 -b $(TF_MAKE_BRANCH) $(TF_MAKE_CLONE_URL) $(TERRAFORM_MAKE_LIB_HOME)
+
+.PHONY : clean
+clean::
+	@ rm -rf $(TERRAFORM_MAKE_LIB_HOME)

--- a/terraform-backend-azurerm.mk
+++ b/terraform-backend-azurerm.mk
@@ -3,22 +3,14 @@ STATE_KEY ?= $(STATE_NAME).tfstate
 AZURERM_BACKEND_SUBSCRIPTION ?= $(ENVIRONMENT)
 BACKEND_TERRAFORM_INIT_ARGS = -backend-config="storage_account_name=$(AZURERM_BACKEND_STORAGE_ACCOUNT_NAME)" -backend-config="container_name=$(STATE_BACKEND_CONTAINER)" -backend-config="access_key=$(AZURERM_BACKEND_STORAGE_ACCOUNT_ACCESS_KEY)" -backend-config="key=$(STATE_KEY)"
 
-ifeq ($(SKIP_BACKEND),true)
-	BACKEND_TERRAFORM_INIT_ARGS = -backend=false
-endif
-
-ifneq ($(SKIP_BACKEND),true)
-	LOCAL_STATE_FILE := $(TERRAFORM_CACHE_DIR)/terraform.tfstate
-endif
-
+init: LOCAL_STATE_FILE := $(TERRAFORM_CACHE_DIR)/terraform.tfstate
 init: CURRENT_STATE_KEY = $(shell if [ -f $(LOCAL_STATE_FILE) ]; then cat $(LOCAL_STATE_FILE) | grep "\"key\":" | awk -F\" '{print $$4}'; fi)
 init: CURRENT_PROFILE = $(shell if [ -f $(LOCAL_STATE_FILE) ]; then cat $(LOCAL_STATE_FILE) | grep "\"profile\":" | awk -F\" '{print $$4}'; fi)
-init:
+init: session
 	$(shell if [ "$(SKIP_BACKEND)" == "false" ] && ([ "$(IS_DEPLOYMENT)" == "true" ] || [ "$(CURRENT_PROFILE)" != "$(AWS_PROFILE)" ] || [ "$(CURRENT_STATE_KEY)" != "$(STATE_KEY)" ]); then echo $(MAKE) force-init; fi)
 
-ensure-backend:
+backend.tf:
 	@echo "terraform { \n  backend \"azurerm\" {} \n}" > backend.tf
-	$(shell if [ "$(SKIP_BACKEND)" == "true" ]; then rm -rf backend.tf; fi)
 
 AZURERM_BACKEND_STATE_ENV_SUFFIX = env:$(ENVIRONMENT)
 ifeq ($(ENVIRONMENT),default)

--- a/terraform-backend-local.mk
+++ b/terraform-backend-local.mk
@@ -2,8 +2,14 @@
 ### Local state
 ###
 
-BACKEND_TERRAFORM_INIT_ARGS := -backend=false
-LOCAL_STATE_FILE := terraform.tfstate.d/$(ENVIRONMENT)/terraform.tfstate
+TERRAFORM_STATE_LOCK := false
+BACKEND_TERRAFORM_INIT_ARGS :=
 
-init:
-	$(shell if [ ! -f $(LOCAL_STATE_FILE) ]; then echo $(MAKE) force-init; fi)
+init: LOCAL_STATE_DIR := terraform.tfstate.d/$(ENVIRONMENT)
+init: session
+	$(shell if [ ! -d $(LOCAL_STATE_DIR) ]; then echo $(MAKE) force-init; fi)
+	@echo "$(ACCOUNT)" > $(TERRAFORM_CACHE_DIR)/backend-local-account
+
+clean-state:
+	@rm -f $(TERRAFORM_CACHE_DIR)/backend-local-account
+	@rm -f $(TERRAFORM_CACHE_DIR)/environment

--- a/terraform-backend-s3.mk
+++ b/terraform-backend-s3.mk
@@ -1,8 +1,11 @@
 ###
 ### S3 backend extension for terraform.mk
 ###
-### Requires aws-session.mk to be included before
+### Requires aws.mk to be included before
 ###
+
+# s3 supports locking
+TERRAFORM_STATE_LOCK := true
 
 # the region where the state backend is located
 STATE_BACKEND_REGION ?= $(DEFAULT_REGION)
@@ -12,13 +15,9 @@ STATE_BACKEND_REGION ?= $(DEFAULT_REGION)
 # => storate container in azure
 STATE_CONTAINER ?= $(ORGANISATION)-terraform-state
 
-STATE_LOCK_TABLE = terraform-state-lock
-
-# the state name is part of the state key
-STATE_NAME ?= account
-
-# the state key
-STATE_KEY ?= $(ACCOUNT)/$(REGION)/$(STATE_NAME).tfstate
+STATE_LOCK_TABLE ?= terraform-state-lock
+STATE_ENCRYPT ?= true
+STATE_ACL ?= authenticated-read
 
 # the kms key to encrypt state files in s3
 VAR_FILE_KMS_KEY_ARN := $(shell if [ -f $(VAR_FILE) ]; then cat $(VAR_FILE) | grep "^kms_key_id[[:space:]]*=" | sed 's/^[^"]*"\(.*\)".*/\1/'; fi)
@@ -28,60 +27,36 @@ else
 	KMS_KEY_ARN ?= $(VAR_FILE_KMS_KEY_ARN)
 endif
 
-STATE_ENCRYPT ?= true
-# no encryption if no backend should be used
-ifeq ($(SKIP_BACKEND),true)
-	STATE_ENCRYPT = false
-endif
+# the state name is part of the state key
+STATE_NAME ?= unknown
 
-ifeq ($(STATE_ENCRYPT),false)
-	KMS_KEY_ARN :=
-endif
+# the state key
+STATE_KEY ?= $(ACCOUNT)/$(REGION)/$(STATE_NAME).tfstate
 
-STATE_BACKEND_S3_CONFIG_INIT_ARGS = -backend-config="bucket=$(STATE_CONTAINER)" -backend-config="key=$(STATE_KEY)" -backend-config="region=$(STATE_BACKEND_REGION)" -backend-config="encrypt=$(STATE_ENCRYPT)" -backend-config="acl=authenticated-read"
-MIN_STATE_BACKEND_S3_CONFIG_INIT_ARGS = $(STATE_BACKEND_S3_CONFIG_INIT_ARGS)
-ifeq ($(TERRAFORM_STATE_LOCK),true)
-	MIN_STATE_BACKEND_S3_CONFIG_INIT_ARGS = $(STATE_BACKEND_S3_CONFIG_INIT_ARGS) -backend-config="dynamodb_table=$(STATE_LOCK_TABLE)"
-endif
-MIN_STATE_BACKEND_S3_INIT_ARGS = $(MIN_STATE_BACKEND_S3_CONFIG_INIT_ARGS)
+BACKEND_TERRAFORM_INIT_ARGS = -backend-config="key=$(STATE_KEY)"
 # only add profile backend config, if not deploying
 # on deployment, the IAM instance profile of the jenkins build slave
 # should be used
 ifneq ($(IS_DEPLOYMENT),true)
-	MIN_STATE_BACKEND_S3_INIT_ARGS = $(MIN_STATE_BACKEND_S3_CONFIG_INIT_ARGS) -backend-config="profile=$(AWS_PROFILE)"
+	BACKEND_TERRAFORM_INIT_ARGS := $(BACKEND_TERRAFORM_INIT_ARGS) -backend-config="profile=$(AWS_PROFILE)"
 endif
 
-BACKEND_TERRAFORM_INIT_ARGS = $(MIN_STATE_BACKEND_S3_INIT_ARGS)
-ifneq ($(KMS_KEY_ARN),)
-	BACKEND_TERRAFORM_INIT_ARGS = $(MIN_STATE_BACKEND_S3_INIT_ARGS) -backend-config="kms_key_id=$(KMS_KEY_ARN)"
-endif
-
-ifeq ($(SKIP_BACKEND),true)
-	BACKEND_TERRAFORM_INIT_ARGS = -backend=false
-endif
-
-ifneq ($(SKIP_BACKEND),true)
-	LOCAL_STATE_FILE := $(TERRAFORM_CACHE_DIR)/terraform.tfstate
-endif
-
-init: CURRENT_STATE_KEY = $(shell if [ -f $(LOCAL_STATE_FILE) ]; then cat $(LOCAL_STATE_FILE) | grep "\"key\":" | awk -F\" '{print $$4}'; fi)
-init: CURRENT_PROFILE = $(shell if [ -f $(LOCAL_STATE_FILE) ]; then cat $(LOCAL_STATE_FILE) | grep "\"profile\":" | awk -F\" '{print $$4}'; fi)
-init: warn-env-credentials
+init: LOCAL_STATE_FILE := $(TERRAFORM_CACHE_DIR)/terraform.tfstate
+init: CURRENT_STATE_KEY := $(shell if [ -f $(LOCAL_STATE_FILE) ]; then cat $(LOCAL_STATE_FILE) | grep "\"key\":" | awk -F\" '{print $$4}'; fi)
+init: CURRENT_PROFILE := $(shell if [ -f $(LOCAL_STATE_FILE) ]; then cat $(LOCAL_STATE_FILE) | grep "\"profile\":" | awk -F\" '{print $$4}'; fi)
+init: backend.tf warn-env-credentials
 	$(shell if [ ! -f $(LOCAL_STATE_FILE) ] || ([ "$(IS_DEPLOYMENT)" != "true" ] && ([ "$(CURRENT_PROFILE)" != "$(AWS_PROFILE)" ] || [ "$(CURRENT_STATE_KEY)" != "$(STATE_KEY)" ])); then echo $(MAKE) force-init; fi)
 
-disable-backend:
-	@$(shell mv backend.tf backend.tf.disabled || true)
+backend.tf: verify-aws
+	@sed 's|$${state_bucket}|$(ORGANISATION)-terraform-state|' $(TERRAFORM_MAKE_LIB_HOME)/terraform-backend-s3.tf.tpl | sed 's|$${state_kms_key_id}|$(KMS_KEY_ARN)|' | sed 's|$${state_region}|$(STATE_BACKEND_REGION)|' | sed 's|$${state_lock_table}|$(STATE_LOCK_TABLE)|' | sed 's|$${state_encrypt}|$(STATE_ENCRYPT)|' | sed 's|$${state_acl}|$(STATE_ACL)|' > backend.tf
 
-enable-backend:
-	@$(shell mv backend.tf.disabled backend.tf || true)
-	@if [[ ! -f backend.tf ]]; then echo "$(RED)Could not enable backend!!$(NC)"; exit 1; fi
-
-backup-local-state: ensure-environment
-	@mv terraform.tfstate.d/$(ENVIRONMENT)/terraform.tfstate $(ACCOUNT)-$(ENVIRONMENT).tfstate
-
-push-local-state: ensure-environment enable-backend force-init ensure-workspace
+push-local-state: ensure-environment force-init ensure-workspace
 	@echo
 	@echo "$(YELLOW)You are uploading a local state to s3$(NC)!!"
 	@read -p "Are you sure? (only yes will be accepted): " deploy; \
 	if [[ $$deploy != "yes" ]]; then exit 1; fi
 	$(TERRAFORM) state push $(ACCOUNT)-$(ENVIRONMENT).tfstate
+
+clean-state:
+	@rm -f $(TERRAFORM_CACHE_DIR)/terraform.tfstate
+	@rm -f $(TERRAFORM_CACHE_DIR)/environment

--- a/terraform-backend-s3.tf.tpl
+++ b/terraform-backend-s3.tf.tpl
@@ -1,0 +1,12 @@
+terraform {
+  backend "s3" {
+    bucket         = "${state_bucket}"
+    kms_key_id     = "${state_kms_key_id}"
+    region         = "${state_region}"
+    encrypt        = ${state_encrypt}
+    acl            = "${state_acl}"
+    dynamodb_table = "${state_lock_table}"
+    key            = "" # set by cli param
+    profile        = "" # set by cli param
+  }
+}

--- a/terraform-local-state-backend-local.mk
+++ b/terraform-local-state-backend-local.mk
@@ -1,0 +1,13 @@
+#
+# Extends terraform-backend-local.mk
+#
+# Fetch ACCOUNT and ENVIRONMENT from local state files
+# and build the VAR_FILE
+#
+
+ifneq ($(wildcard $(TERRAFORM_CACHE_DIR)/backend-local-account),)
+	LOCAL_STATE_ACCOUNT = $(shell cat $(TERRAFORM_CACHE_DIR)/backend-local-account)
+ifneq ($(wildcard $(TERRAFORM_CACHE_DIR)/environment),)
+	VAR_FILE := $(LOCAL_STATE_ACCOUNT)-$(shell cat $(TERRAFORM_CACHE_DIR)/environment).tfvars
+endif
+endif

--- a/terraform-local-state-backend-s3.mk
+++ b/terraform-local-state-backend-s3.mk
@@ -1,0 +1,11 @@
+#
+# Extends terraform-backend-s3.mk
+#
+# Fetch ACCOUNT and ENVIRONMENT from local state files
+# and build the VAR_FILE
+#
+
+INIT_STATE_FILE := $(TERRAFORM_CACHE_DIR)/terraform.tfstate
+ifneq ($(wildcard $(INIT_STATE_FILE)),)
+	VAR_FILE := $(shell cat $(INIT_STATE_FILE) | grep "\"profile\":" | awk -F\" '{print $$4}' | awk -F- '{print $$2}')-$(shell cat $(INIT_STATE_FILE) | grep "\"profile\":" | awk -F\" '{print $$4}' | awk -F- '{print $$3}').tfvars
+endif

--- a/terraform.mk
+++ b/terraform.mk
@@ -5,17 +5,11 @@
 ### and/or backend state config
 ###
 ### Public variables:
-###   - ENVIRONMENT (required before include)
-###   - ORGANISATION
-###   - ACCOUNT
-###   - ACCOUNT_ID
-###   - REGION
-###   - DEFAULT_REGION
-###   - STATE_BACKEND_REGION
-###   - STATE_BACKEND_CONTAINER
-###   - STATE_NAME
-###   - STATE_KEY
-###   - PROVIDER_TERRAFORM_INIT_ARGS => an extension can introduce this variable to control initialisation
+###   - VAR_FILE         => a terraform tfvars file (required)
+###   - DEFAULT_VAR_FILE => variables shared between environments, default: default.tfvars
+###   - PROVIDER         => aws and azure are currently supported, default: aws
+###   - BACKEND_TYPE     => s3 and azurerm arecurrently supported, default: s3
+###   - STATE_NAME       => the state filename, default: unknown
 ###
 ### Public targets:
 ###   - fmt              => format terraform code recursively
@@ -28,13 +22,10 @@
 ###   - refresh			 => refresh the state
 ###
 ### Extension targets:
-###   - install-community-plugins => should install plugins that cannot be installed by terraform init
 ###   - init                      => By default, the backend is always initialized on every call that
 ###                                  operates on the state. If it is posible to determine if a re-initialisation
 ###                                  this target should be extended to conditionally call force-init
-###   - verify-active-session     => should fail, if no valid credentials can be found or the session is expired
 ###   - session                   => Get a new session for the cooresponding provider
-###	  - ensure-backend            => create backend.tf file containing the backend decalration
 ###   - backup-state			  => will be called befor modifying the state.
 ###   - debug			          => Add some variable values to debug oputput
 ###   - before-state-modification => will be called before all targets that modify the state (refresh, plan, apply)
@@ -68,40 +59,6 @@ ifeq ($(TERRAFORM_CACHE_DIR),)
 	TERRAFORM_CACHE_DIR := .terraform
 endif
 
-# terraforms state dir. state initialization is done here
-TERRAFORM_STATE_DIR := terraform.tfstate.d
-
-# if no specific backend gets loaded, this setting has no effect
-# backends MUST clear all backend initialisation parameters if this is set to true
-SKIP_BACKEND ?= false
-
-# wether to lock state operations
-# defaults to true
-# may be disabled for backend that do not support locking
-TERRAFORM_STATE_LOCK ?= true
-ifeq ($(SKIP_BACKEND),true)
-	TERRAFORM_STATE_LOCK = false
-	BACKEND_TYPE =
-endif
-
-ifeq ($(VERBOSE),true)
-	VERBOSE := true
-	VERBOSE_ARG :=
-	SILENT := false
-else
-	VERBOSE := false
-	VERBOSE_ARG := &> /dev/null
-	SILENT ?= false
-endif
-
-ifeq ($(SILENT),true)
-	SILENT := true
-	SILENT_ARG := &> /dev/null
-else
-	SILENT := false
-	SILENT_ARG :=
-endif
-
 # indicates a deployment
 # this causes this build tool to omit profile configuration
 # on terraform backend initialisation to delegate that to IAM instance profile
@@ -115,20 +72,41 @@ IS_DEPLOYMENT ?= false
 # used to display warning when attempting to deploy to this environment
 PRODUCTION_ENVIRONMENT_NAME ?= prod
 
-# var file to load environment specific values from
-# defaults to terraform.tfvars
-VAR_FILE ?= terraform.tfvars
+# default provider and backend
+TERRAFORM_PROVIDER ?= aws
+BACKEND_TYPE ?= s3
+
+# VAR_FILE is the main parameter source in terraform tfvars format
+# This is required, but if a state has been initialized,
+# we can try to load the file name from there
+ifeq ($(VAR_FILE),)
+-include $(TERRAFORM_MAKE_LIB_HOME)/terraform-local-state-backend-$(BACKEND_TYPE).mk
+endif
+
+# still empty? use the default
+ifeq ($(VAR_FILE),)
+	VAR_FILE := default.tfvars
+endif
+
+# DEFAULT_VAR_FILE will always be loaded. defaults to VAR_FILE if emtpy
 DEFAULT_VAR_FILE ?= default.tfvars
 ifeq ($(wildcard $(DEFAULT_VAR_FILE)),)
+	# no default var file? use the VAR_FILE instead
 	DEFAULT_VAR_FILE = $(VAR_FILE)
 endif
 
-# the environment of this configuration
-VAR_FILE_ENVIRONMENT := $(shell if [ -f "$(VAR_FILE)" ]; then cat $(VAR_FILE) | grep "^environment[[:space:]]*=" | sed 's/^[^"]*"\(.*\)".*/\1/'; fi)
-ifeq ($(VAR_FILE_ENVIRONMENT),)
-	ENVIRONMENT ?= $(shell if [ -f "$(DEFAULT_VAR_FILE)" ]; then cat $(DEFAULT_VAR_FILE) | grep "^environment[[:space:]]*=" | sed 's/^[^"]*"\(.*\)".*/\1/'; fi)
-else
-	ENVIRONMENT ?= $(VAR_FILE_ENVIRONMENT)
+# determine the environment
+ENVIRONMENT := $(shell if [ -f "$(VAR_FILE)" ]; then cat $(VAR_FILE) | grep "^environment[[:space:]]*=" | sed 's/^[^"]*"\(.*\)".*/\1/'; fi)
+ifeq ($(ENVIRONMENT),)
+	# fallback to default
+	ENVIRONMENT := $(shell if [ -f "$(DEFAULT_VAR_FILE)" ]; then cat $(DEFAULT_VAR_FILE) | grep "^environment[[:space:]]*=" | sed 's/^[^"]*"\(.*\)".*/\1/'; fi)
+endif
+
+# if no environment is specified, use the default environment without a backend
+# this is mainly used for targets that need basic initialization (e.g. validate)
+ifeq ($(ENVIRONMENT),)
+	ENVIRONMENT := default
+	BACKEND_TYPE :=
 endif
 
 # this contains the actual file name of the current plan
@@ -142,11 +120,7 @@ CURRENT_PLAN_FILE := $(shell if [ -f "$(CURRENT_PLAN)" ]; then cat $(CURRENT_PLA
 # backends MUST override this setting
 PLAN_OUT := $(TERRAFORM_PLAN_DIR)/$(ENVIRONMENT).plan
 
-LOCAL_STATE_FILE ?= $(TERRAFORM_STATE_DIR)/$(ENVIRONMENT)/terraform.tfstate
-ifeq ($(ENVIRONMENT),default)
-	LOCAL_STATE_FILE = terraform.tfstate
-endif
-
+# include provider and backend plugins
 -include $(TERRAFORM_MAKE_LIB_HOME)/$(TERRAFORM_PROVIDER).mk
 -include $(TERRAFORM_MAKE_LIB_HOME)/terraform-backend-$(BACKEND_TYPE).mk
 
@@ -170,23 +144,16 @@ debug-default:
 	@echo CURRENT_PLAN_FILE=$(CURRENT_PLAN_FILE)
 	@echo PLAN=$(PLAN)
 	@echo PLAN_OUT=$(PLAN_OUT)
-	@echo LOCAL_STATE_FILE=$(LOCAL_STATE_FILE)
 	@echo STATE_KEY=$(STATE_KEY)
 	@echo IS_DEPLOYMENT=$(IS_DEPLOYMENT)
-	@echo SKIP_BACKEND=$(SKIP_BACKEND)
 	@echo BACKEND_TYPE=$(BACKEND_TYPE)
-	@echo VERBOSE_ARG=$(VERBOSE_ARG)
-ifeq ($(VERBOSE),true)
 	@echo TERRAFORM_CMD=$(TERRAFORM_CMD)
 	@echo TERRAFORM=$(TERRAFORM)
 	@echo TERRAFORM_PLAN_DIR=$(TERRAFORM_PLAN_DIR)
 	@echo TERRAFORM_CACHE_DIR=$(TERRAFORM_CACHE_DIR)
-	@echo TERRAFORM_STATE_DIR=$(TERRAFORM_STATE_DIR)
-	@echo TERRAFORM_STATE_LOCK=$(TERRAFORM_STATE_LOCK)
 	@echo PRODUCTION_ENVIRONMENT_NAME=$(PRODUCTION_ENVIRONMENT_NAME)
 	@echo EXPIRE=$(EXPIRE)
 	@echo MIN_PERSIST=$(MIN_PERSIST)
-endif
 
 ###
 ### extension targets
@@ -196,16 +163,12 @@ endif
 %: %-default
 	@ true
 
+# if the local state file is missing or a deployment is in progress, we need to initialize
+# this target can be extended by backends
+init-default: force-init
+
 # should install plugins that cannot be installed by terraform init
 install-community-plugins-default:
-	@ true
-
-# should fail, if no valid credentials can be found or the session is expired
-verify-active-session-default:
-	@ true
-
-# should create a backend.tf file contining the base backend declaration
-ensure-backend-default:
 	@ true
 
 # get a new session
@@ -224,6 +187,16 @@ before-state-modification-default:
 before-init-default:
 	@ true
 
+# each backend can provide a backend.tf target, which
+# should create the backend.tf file which contains the terraform backend config
+# no backend config if no backend plugin is loaded
+backend.tf-default: remove-backend
+
+# each backend should implement this target
+# which should clean up local files related to the state
+clean-state-default:
+	@ true
+
 ###
 ###
 ### validation
@@ -239,7 +212,6 @@ validate-fmt:
 	@echo "==> $(GREEN)Ok.$(NC)"
 
 # validate code
-validate-code: SKIP_BACKEND := true
 validate-code: init
 	$(TERRAFORM) validate
 
@@ -248,7 +220,7 @@ fmt:
 	@$(TERRAFORM) fmt -recursive
 
 # format and validate
-fmt-and-validate: init fmt validate
+fmt-and-validate: fmt validate
 
 ensure-plan-dir-exists:
 	@mkdir -p $(TERRAFORM_PLAN_DIR)
@@ -260,8 +232,6 @@ ensure-plan-dir-exists:
 # force remove terraform cache dir
 force-clean-terraform-cache: clean-terraform-cache
 	@rm -rf $(TERRAFORM_CACHE_DIR)
-	@rm -rf $(TERRAFORM_STATE_DIR)
-	@rm -rf terraform.tfstate
 
 # ensure terraform needs to re-init
 # modules and plgins will not be removed
@@ -274,10 +244,10 @@ clean-terraform-plans:
 	@rm -rf exit_status.txt
 
 # clean plans and terraform cache
-clean-all: clean-terraform-cache clean-terraform-plans
+clean-all: clean-terraform-cache clean-terraform-plans remove-backend
 
 # clean plans and terraform cache
-force-clean-all: force-clean-terraform-cache clean-terraform-plans
+force-clean-all: force-clean-terraform-cache clean-terraform-plans remove-backend
 
 ###
 ### default
@@ -288,33 +258,26 @@ default: fmt validate
 ###
 ### initialzation
 ###
-TF_ARGS_INIT = -lock=$(TERRAFORM_STATE_LOCK) $(BACKEND_TERRAFORM_INIT_ARGS)
-ifeq ($(SKIP_BACKEND),true)
-	TF_ARGS_INIT = -lock=false -backend=false
-endif
+TF_ARGS_INIT = $(BACKEND_TERRAFORM_INIT_ARGS)
 
 # force re-initialization of terraform state
-force-init: install-community-plugins session ensure-backend before-init
-	@rm -rf $(TERRAFORM_CACHE_DIR)/terraform.tfstate
-	@rm -rf $(TERRAFORM_CACHE_DIR)/environment
-	$(TERRAFORM) init $(TF_ARGS_INIT) $(SILENT_ARG)
+force-init: backend.tf install-community-plugins before-init clean-state .tf-init
+	@$(MAKE) ensure-workspace
 
-# if the local state file is missing or a deployment is in progress, we need to initialize
-# this target can be extended by backends
-init-default: session
-	echo $(MAKE) force-init
+.tf-init: session
+	$(TERRAFORM) init $(TF_ARGS_INIT)
 
 # update modules
 update-modules:
-	$(TERRAFORM) get -update=true $(SILENT_ARG)
+	$(TERRAFORM) get -update=true
 
 # create a new workspace
-create-workspace: session init
+create-workspace: init
 	@$(TERRAFORM) workspace select $(ENVIRONMENT) &> /dev/null || $(TERRAFORM) workspace new $(ENVIRONMENT)
 
 # ensure workspace selected
-ensure-workspace: session init ensure-backend
-	@if [ "$(shell $(TERRAFORM) workspace show)" != "$(ENVIRONMENT)" ]; then $(TERRAFORM) workspace select $(ENVIRONMENT) $(SILENT_ARG) || $(TERRAFORM) workspace new $(ENVIRONMENT); fi
+ensure-workspace: init
+	@if [ "$(shell $(TERRAFORM) workspace show)" != "$(ENVIRONMENT)" ]; then $(TERRAFORM) workspace select $(ENVIRONMENT)  || $(TERRAFORM) workspace new $(ENVIRONMENT); fi
 
 # list configured workspaces
 list-configured-workspaces:
@@ -322,7 +285,7 @@ list-configured-workspaces:
 	@find . -name "$(ACCOUNT)-*.tfvars" | grep -v default | awk -F'-' '{print $$2}' | sed 's/.tfvars//' | sort -u
 
 # list workspaces that exist in backend
-list-existing-workspaces: session init
+list-existing-workspaces: init
 	@echo "$(YELLOW)Workspaces created for $(GREEN)$(ACCOUNT)$(NC)$(YELLOW):$(NC)"
 	@$(TERRAFORM) workspace list | grep -v default | sed 's/* //' | sort -u
 
@@ -332,7 +295,14 @@ list-workspaces: list-configured-workspaces list-existing-workspaces
 ###
 ### plan
 ###
-TF_ARGS_LOCK = -lock=$(TERRAFORM_STATE_LOCK)
+TERRAFORM_STATE_LOCK ?= false
+ifeq ($(TERRAFORM_STATE_LOCK),true)
+	TF_ARGS_LOCK := -lock=$(TERRAFORM_STATE_LOCK)
+endif
+ifeq ($(DISABLE_STATE_LOCK),true)
+	TF_ARGS_LOCK :=
+endif
+
 TF_ARGS_VAR_IS_DEPLOYMENT = -var 'is_deployment=$(IS_DEPLOYMENT)'
 TF_ARGS_VAR_FILE = -var-file '$(VAR_FILE)'
 ifneq ($(DEFAULT_VAR_FILE),$(VAR_FILE))
@@ -347,9 +317,9 @@ ifeq ($(WRITE_PLAN_STATUS),true)
 endif
 
 # create a new plan, if not exists
-plan: check-plan-missing session ensure-workspace validate before-state-modification
+plan: check-plan-missing ensure-workspace validate before-state-modification
 	@rm -f exit_code.txt
-	$(TERRAFORM) plan $(TF_ARGS_PLAN) -out=$(PLAN_OUT) $(SILENT_ARG) $(WRITE_PLAN_STATUS_ARG)
+	$(TERRAFORM) plan $(TF_ARGS_PLAN) -out=$(PLAN_OUT)  $(WRITE_PLAN_STATUS_ARG)
 	@echo $(PLAN_OUT) > $(CURRENT_PLAN)
 	@echo "$(GREEN)Plan created at $(YELLOW)$(PLAN_OUT)$(GREEN) and made current.$(NC)"
 	@echo "$(GREEN)Apply with 'make apply'$(NC)"
@@ -380,7 +350,7 @@ current-plan:
 	@echo $(PLAN)
 
 # create a destructive plan
-plan-destroy: check-plan-missing session ensure-workspace validate before-state-modification
+plan-destroy: check-plan-missing ensure-workspace validate before-state-modification
 	$(TERRAFORM) plan $(TF_ARGS_PLAN) -out=$(PLAN_OUT) -destroy
 	@echo $(PLAN_OUT) > $(CURRENT_PLAN)
 	@echo ""
@@ -403,27 +373,45 @@ endif
 endif
 
 # apply plan
-apply: check-plan-exists prompt-for-production session ensure-workspace validate backup-state before-state-modification
-	$(TERRAFORM) apply $(TF_ARGS_LOCK) $(PLAN) $(SILENT_ARG)
+apply: check-plan-exists prompt-for-production ensure-workspace validate backup-state before-state-modification
+	$(TERRAFORM) apply $(TF_ARGS_LOCK) $(PLAN)
 	@rm -f $(CURRENT_PLAN_FILE)
 	@rm -f $(PLAN)
 
 force-apply: prompt-for-production session ensure-workspace validate backup-state before-state-modification
-	$(TERRAFORM) apply $(TF_ARGS_PLAN) -auto-approve $(SILENT_ARG)
+	$(TERRAFORM) apply $(TF_ARGS_PLAN) -auto-approve
 
 ###
 ### state and info
 ###
 
 # list resources in the state
-list: session ensure-workspace
+list: ensure-workspace
 	$(TERRAFORM) state list
 
 # display output variables from the state
 output: ITEM ?=
-output: session ensure-workspace
+output: ensure-workspace
 	$(TERRAFORM) output $(ITEM)
 
 # update the state with information from infrastructure
-refresh: session ensure-workspace backup-state before-state-modification
+refresh: ensure-workspace backup-state before-state-modification
 	$(TERRAFORM) refresh $(TF_ARGS_PLAN)
+
+###
+### maintain the backend config
+###
+remove-backend:
+	@$(shell rm -f backend.tf*)
+
+disable-backend:
+	@$(shell mv backend.tf backend.tf.disabled || true)
+
+enable-backend:
+	@$(shell mv backend.tf.disabled backend.tf || true)
+	@if [[ ! -f backend.tf ]]; then echo "$(RED)Could not enable backend!!$(NC)"; exit 1; fi
+
+re-write-backend: remove-backend backend.tf
+
+backup-local-state:
+	@mv terraform.tfstate.d terraform.tfstate.d.backup


### PR DESCRIPTION
* add defaults for provider and backend type
* MFA token for AWS session can now be fetched by exporting AWS_MFA_TOKEN_CMD env variable 
* Backend config `backend.tf` is now fully maintained. => `backend.tf` can be added to gitignore
* Once an environment has been initialised, the VAR_FILE parameter can now be omitted on subsequent commands
* add installer